### PR TITLE
Dynamic json parsing websocket

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -1,7 +1,12 @@
 package sfox
 
 import (
+	"errors"
 	"fmt"
+)
+
+var (
+	ErrUnknownPayload = errors.New("Unknown payload")
 )
 
 type ErrHttp struct {


### PR DESCRIPTION
This is a breaking change that simplifies the code for parsing
websocket messages. The Msg is now a WebsocketEnvelope and has a
`.Payload()` receiver that will dynamically parse the websocket type.
`TickerMsg`, `TradeMsg`, or `OrderbookMsg`